### PR TITLE
Change default perms to prevent teleporting instantly out of combat

### DIFF
--- a/AreaShop/src/main/resources/plugin.yml
+++ b/AreaShop/src/main/resources/plugin.yml
@@ -151,7 +151,7 @@ permissions:
     default: op
   areashop.teleportfriendsign:
     description: Teleport to the sign of regions where you are added as friend
-    default: false
+    default: op
   areashop.setteleport:
     description: Set the teleport spot for your region
     default: op

--- a/AreaShop/src/main/resources/plugin.yml
+++ b/AreaShop/src/main/resources/plugin.yml
@@ -136,25 +136,25 @@ permissions:
     default: false
   areashop.teleport:
     description: Teleport to your region
-    default: false
+    default: op
   areashop.teleportall:
     description: Teleport to all regions
     default: op
   areashop.teleportsign:
     description: Teleport to signs of regions you own
-    default: false
+    default: op
   areashop.teleportsignall:
     description: Teleport to signs of all regions
     default: op
   areashop.teleportfriend:
     description: Teleport to regions where you are added as friend
-    default: false
+    default: op
   areashop.teleportfriendsign:
     description: Teleport to the sign of regions where you are added as friend
     default: false
   areashop.setteleport:
     description: Set the teleport spot for your region
-    default: false
+    default: op
   areashop.setteleportall:
     description: Set the teleport for other regions
     default: op
@@ -166,7 +166,7 @@ permissions:
     default: op
   areashop.find:
     description: Allows you to teleport to a free region (/as find)
-    default: false
+    default: op
   areashop.groupadd:
     description: Allows you to add regions to groups
     default: op

--- a/AreaShop/src/main/resources/plugin.yml
+++ b/AreaShop/src/main/resources/plugin.yml
@@ -136,25 +136,25 @@ permissions:
     default: false
   areashop.teleport:
     description: Teleport to your region
-    default: true
+    default: false
   areashop.teleportall:
     description: Teleport to all regions
     default: op
   areashop.teleportsign:
     description: Teleport to signs of regions you own
-    default: true
+    default: false
   areashop.teleportsignall:
     description: Teleport to signs of all regions
     default: op
   areashop.teleportfriend:
     description: Teleport to regions where you are added as friend
-    default: true
+    default: false
   areashop.teleportfriendsign:
     description: Teleport to the sign of regions where you are added as friend
-    default: true
+    default: false
   areashop.setteleport:
     description: Set the teleport spot for your region
-    default: true
+    default: false
   areashop.setteleportall:
     description: Set the teleport for other regions
     default: op
@@ -166,7 +166,7 @@ permissions:
     default: op
   areashop.find:
     description: Allows you to teleport to a free region (/as find)
-    default: true
+    default: false
   areashop.groupadd:
     description: Allows you to add regions to groups
     default: op


### PR DESCRIPTION
Players on PvP servers can escape a pvp battle by teleporting to a shop region instantly