### PR TITLE
Short-circuit logic should be used in boolean contexts

### DIFF
--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/AreaShop.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/AreaShop.java
@@ -192,7 +192,7 @@ public final class AreaShop extends JavaPlugin implements AreaShopInterface {
         
 		// Load all data from files and check versions
 	    fileManager = new FileManager(this);
-	    error = error | !fileManager.loadFiles();
+	    error = error || !fileManager.loadFiles();
 	    
 	    // Print loaded version of WG and WE in debug
 	    if(wgVersion != null) {

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/managers/FileManager.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/managers/FileManager.java
@@ -79,7 +79,7 @@ public class FileManager {
 		schemFolder = plugin.getDataFolder() + File.separator + AreaShop.schematicFolder;
 		worldRegionsRequireSaving = new HashSet<>();
 		File schemFile = new File(schemFolder);
-		if(!schemFile.exists() & !schemFile.mkdirs()) {
+		if(!schemFile.exists() && !schemFile.mkdirs()) {
 			plugin.getLogger().warning("Could not create schematic files directory: " + schemFile.getAbsolutePath());
 		}
 		loadVersions();
@@ -989,7 +989,7 @@ public class FileManager {
 			boolean buyFileFound = false, rentFileFound = false;
 			if(rentFile.exists()) {
 				rentFileFound = true;
-				if(!oldFolderFile.exists() & !oldFolderFile.mkdirs()) {
+				if(!oldFolderFile.exists() && !oldFolderFile.mkdirs()) {
 					plugin.getLogger().warning("Could not create directory: " + oldFolderFile.getAbsolutePath());
 				}
 				
@@ -1063,7 +1063,7 @@ public class FileManager {
 					}		
 					// Save rents to new format
 					File regionsFile = new File(regionsPath);
-					if(!regionsFile.exists() & !regionsFile.mkdirs()) {
+					if(!regionsFile.exists() && !regionsFile.mkdirs()) {
 						plugin.getLogger().warning("Could not create directory: " + regionsFile.getAbsolutePath());
 						return;
 					}
@@ -1113,7 +1113,7 @@ public class FileManager {
 			}
 			if(buyFile.exists()) {
 				buyFileFound = true;
-				if(!oldFolderFile.exists() & !oldFolderFile.mkdirs()) {
+				if(!oldFolderFile.exists() && !oldFolderFile.mkdirs()) {
 					plugin.getLogger().warning("Could not create directory: " + oldFolderFile.getAbsolutePath());
 					return;
 				}
@@ -1189,7 +1189,7 @@ public class FileManager {
 				
 					// Save buys to new format
 					File regionsFile = new File(regionsPath);
-					if(!regionsFile.exists() & !regionsFile.mkdirs()) {
+					if(!regionsFile.exists() && !regionsFile.mkdirs()) {
 						plugin.getLogger().warning("Could not create directory: " + regionsFile.getAbsolutePath());
 					}
 					for(HashMap<String, String> buy : buys.values()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2178 Short-circuit logic should be used in boolean contexts

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2178 

Please let me know if you have any questions.

Zeeshan Asghar