### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/Utils.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/Utils.java
@@ -67,7 +67,7 @@ public class Utils {
 		try {
 			Method onlinePlayerMethod = Server.class.getMethod("getOnlinePlayers");
 			if(onlinePlayerMethod.getReturnType().equals(Collection.class)) {
-				return ((Collection<? extends Player>)onlinePlayerMethod.invoke(Bukkit.getServer()));
+				return (Collection<? extends Player>)onlinePlayerMethod.invoke(Bukkit.getServer());
 			} else {
 				return Arrays.asList((Player[])onlinePlayerMethod.invoke(Bukkit.getServer()));
 			}
@@ -422,7 +422,7 @@ public class Utils {
 		}
 
 		// check if the part before the space is a number
-		String prefix = time.substring(0, (time.indexOf(' ')));
+		String prefix = time.substring(0, time.indexOf(' '));
 		return prefix.matches("\\d+");
 	}
 

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/AddCommand.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/AddCommand.java
@@ -142,9 +142,9 @@ public class AddCommand extends CommandAreaShop {
 							namesNoPermission.add(region.getId());
 						} else {
 							// Check if the player should be landlord
-							boolean landlord = (!sender.hasPermission("areashop.create" + type)
+							boolean landlord = !sender.hasPermission("areashop.create" + type)
 								&& ((sender.hasPermission("areashop.create" + type + ".owner") && isOwner)
-									|| (sender.hasPermission("areashop.create" + type + ".member") && isMember)));
+									|| (sender.hasPermission("areashop.create" + type + ".member") && isMember));
 							if(isRent) {
 								RentRegion rent = new RentRegion(plugin, region.getId(), finalWorld);
 								// Set landlord

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/listeners/SignChangeListener.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/listeners/SignChangeListener.java
@@ -136,9 +136,9 @@ public final class SignChangeListener implements Listener {
 				final RentRegion rent = new RentRegion(plugin, secondLine, event.getPlayer().getWorld());
 				boolean isMember = plugin.getWorldGuardHandler().containsMember(rent.getRegion(), player.getUniqueId());
 				boolean isOwner = plugin.getWorldGuardHandler().containsOwner(rent.getRegion(), player.getUniqueId());
-				boolean landlord = (!player.hasPermission("areashop.createrent")
+				boolean landlord = !player.hasPermission("areashop.createrent")
 						&& ((player.hasPermission("areashop.createrent.owner") && isOwner)
-						|| (player.hasPermission("areashop.createrent.member") && isMember)));					
+						|| (player.hasPermission("areashop.createrent.member") && isMember));					
 
 				if(landlord) {
 					rent.setLandlord(player.getUniqueId(), player.getName());
@@ -247,9 +247,9 @@ public final class SignChangeListener implements Listener {
 				final BuyRegion buy = new BuyRegion(plugin, secondLine, event.getPlayer().getWorld());
 				boolean isMember = plugin.getWorldGuardHandler().containsMember(buy.getRegion(), player.getUniqueId());
 				boolean isOwner = plugin.getWorldGuardHandler().containsOwner(buy.getRegion(), player.getUniqueId());
-				boolean landlord = (!player.hasPermission("areashop.createbuy")
+				boolean landlord = !player.hasPermission("areashop.createbuy")
 						&& ((player.hasPermission("areashop.createbuy.owner") && isOwner)
-						|| (player.hasPermission("areashop.createbuy.member") && isMember)));					
+						|| (player.hasPermission("areashop.createbuy.member") && isMember));					
 
 				if(landlord) {
 					buy.setLandlord(player.getUniqueId(), player.getName());

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/GeneralRegion.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/GeneralRegion.java
@@ -1718,7 +1718,7 @@ public abstract class GeneralRegion implements GeneralRegionInterface, Comparabl
 	public boolean matchesLimitGroup(String group) {
 		List<String> worlds = plugin.getConfig().getStringList("limitGroups." + group + ".worlds");
 		List<String> groups = plugin.getConfig().getStringList("limitGroups." + group + ".groups");
-		if((worlds == null || worlds.isEmpty() || worlds.contains(getWorldName()))) {
+		if(worlds == null || worlds.isEmpty() || worlds.contains(getWorldName())) {
 			if(groups == null || groups.isEmpty()) {
 				return true;
 			} else {

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/RentRegion.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/RentRegion.java
@@ -307,7 +307,7 @@ public class RentRegion extends GeneralRegion {
 	 */
 	public double getMoneyBackAmount() {
 		Long currentTime = Calendar.getInstance().getTimeInMillis();
-		Double timeLeft = (double) ((getRentedUntil() - currentTime));
+		Double timeLeft = (double) (getRentedUntil() - currentTime);
 		double percentage = (getMoneyBackPercentage()) / 100.0;
 		Double timePeriod = (double) (getDuration());
 		double periods = timeLeft / timePeriod;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck 

Please let me know if you have any questions.

Zeeshan Asghar