### PR TITLE
Math operands should be cast before assignment

### DIFF
--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/Metrics.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/Metrics.java
@@ -220,7 +220,7 @@ public class Metrics {
                         }
                     }
                 }
-            }, 0, PING_INTERVAL * 1200);
+            }, 0, PING_INTERVAL * 1200L);
 
             return true;
         }

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/StackCommand.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/StackCommand.java
@@ -103,13 +103,13 @@ public class StackCommand extends CommandAreaShop {
 		}
 		final Location shift = new Location(selection.getWorld(), 0, 0, 0);
 		if(facing == BlockFace.SOUTH) {
-			shift.setZ(-selection.getLength() - gap);
+			shift.setZ(-selection.getLength() - (double)gap);
 		} else if(facing == BlockFace.WEST) {
-			shift.setX(selection.getWidth() + gap);
+			shift.setX(selection.getWidth() + (double)gap);
 		} else if(facing == BlockFace.NORTH) {
-			shift.setZ(selection.getLength() + gap);
+			shift.setZ(selection.getLength() + (double)gap);
 		} else if(facing == BlockFace.EAST) {
-			shift.setX(-selection.getWidth() - gap);
+			shift.setX(-selection.getWidth() - (double)gap);
 		}
 		AreaShop.debug("  calculated shift vector: " + shift + ", with facing=" + facing);
 		// Create regions and add them to AreaShop


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

Squid:S2184  Math operands should be cast before assignment

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/Squid:S2184  

Please let me know if you have any questions.

Zeeshan Asghar