### PR TITLE
Declarations should use Java collection interfaces such as 'List' rather than specific implementation classes such as LinkedList

### DIFF
--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/managers/CommandManager.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/managers/CommandManager.java
@@ -67,7 +67,7 @@ public class CommandManager implements CommandExecutor, TabCompleter {
 	 * Get the list with AreaShop commands
 	 * @return The list with AreaShop commands
 	 */
-	public ArrayList<CommandAreaShop> getCommands() {
+	public List<CommandAreaShop> getCommands() {
 		return commands;
 	}
 	

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/BuyRegion.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/BuyRegion.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 public class BuyRegion extends GeneralRegion {
@@ -209,7 +210,7 @@ public class BuyRegion extends GeneralRegion {
 	}
 	
 	@Override
-	public HashMap<String, Object> getSpecificReplacements() {
+	public Map<String, Object> getSpecificReplacements() {
 		// Fill the replacements map with things specific to a BuyRegion
 		HashMap<String, Object> result = new HashMap<>();
 		result.put(AreaShop.tagPrice, getFormattedPrice());

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/GeneralRegion.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/GeneralRegion.java
@@ -198,7 +198,7 @@ public abstract class GeneralRegion implements GeneralRegionInterface, Comparabl
 	 * Get the tag replacements, used in commands or signs
 	 * @return A map with strings like '%region%' linking to the value to replace it with
 	 */
-	public abstract HashMap<String, Object> getSpecificReplacements();
+	public abstract Map<String, Object> getSpecificReplacements();
 	
 	/**
 	 * Get the state of a region
@@ -499,13 +499,13 @@ public abstract class GeneralRegion implements GeneralRegionInterface, Comparabl
 	 * Get all the replacements for this region
 	 * @return Map with the keys that need to be replaced with the value of the object
 	 */
-	public HashMap<String, Object> getAllReplacements() {
+	public Map<String, Object> getAllReplacements() {
 		// Reply with cache if we have one
 		if(replacementsCache != null && (Calendar.getInstance().getTimeInMillis() - replacementsCacheTime) < 1000) {
 			return replacementsCache;
 		}
 		
-		HashMap<String, Object> result = getSpecificReplacements();
+		HashMap<String, Object> result = (HashMap<String, Object>) getSpecificReplacements();
 		
 		result.put(AreaShop.tagRegionName, getName());
 		result.put(AreaShop.tagRegionType, getType().getValue().toLowerCase());
@@ -567,7 +567,7 @@ public abstract class GeneralRegion implements GeneralRegionInterface, Comparabl
 			//AreaShop.debug("match=" + match + ", key=" + key + ", lanString=" + languageString + ", replaced=" + source);
 		}		
 		// Apply static replacements
-		HashMap<String, Object> replacements = getAllReplacements();
+		HashMap<String, Object> replacements = (HashMap<String, Object>) getAllReplacements();
 		for(String tag : replacements.keySet()) {
 			Object replacement = replacements.get(tag);
 			if(replacement != null) {

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/RentRegion.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/RentRegion.java
@@ -19,6 +19,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 public class RentRegion extends GeneralRegion {
@@ -129,7 +130,7 @@ public class RentRegion extends GeneralRegion {
 	}
 	
 	@Override
-	public HashMap<String, Object> getSpecificReplacements() {
+	public Map<String, Object> getSpecificReplacements() {
 		// Fill the replacements map with things specific to a RentRegion
 		HashMap<String, Object> result = new HashMap<>();
 		result.put(AreaShop.tagPrice, getFormattedPrice());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1319 Declarations should use Java collection interfaces such as 'List' rather than specific implementation classes such as LinkedList

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319 

Please let me know if you have any questions.

Zeeshan Asghar