### PR TITLE
Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/Metrics.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/Metrics.java
@@ -374,7 +374,7 @@ public class Metrics {
             appendJSONPair(json, "ping", "1");
         }
 
-        if(graphs.size() > 0) {
+        if(!graphs.isEmpty()) {
             synchronized(graphs) {
                 json.append(',');
                 json.append('"');

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/AddCommand.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/AddCommand.java
@@ -72,7 +72,7 @@ public class AddCommand extends CommandAreaShop {
 			}
 			world = selection.getWorld();
 			regions = Utils.getWERegionsInSelection(selection);
-			if(regions.size() == 0) {
+			if(regions.isEmpty()) {
 				plugin.message(player, "cmd-noWERegionsFound");
 				return;
 			}

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/DelCommand.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/DelCommand.java
@@ -56,7 +56,7 @@ public class DelCommand extends CommandAreaShop {
 				return;
 			}			
 			List<GeneralRegion> regions = Utils.getASRegionsInSelection(selection);
-			if(regions == null || regions.size() == 0) {
+			if(regions == null || regions.isEmpty()) {
 				plugin.message(player, "cmd-noRegionsFound");
 				return;
 			}
@@ -83,10 +83,10 @@ public class DelCommand extends CommandAreaShop {
 				Bukkit.getPluginManager().callEvent(new RemovedRegionEvent(region));
 			}
 			// send messages
-			if(namesSuccess.size() != 0) {
+			if(!namesSuccess.isEmpty()) {
 				plugin.message(sender, "del-success", Utils.createCommaSeparatedList(namesSuccess));
 			}
-			if(namesFailed.size() != 0) {
+			if(!namesFailed.isEmpty()) {
 				plugin.message(sender, "del-failed", Utils.createCommaSeparatedList(namesFailed));
 			}
 		} else {

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/GroupaddCommand.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/GroupaddCommand.java
@@ -57,7 +57,7 @@ public class GroupaddCommand extends CommandAreaShop {
 				return;
 			}
 			List<GeneralRegion> regions = Utils.getASRegionsInSelection(selection);
-			if(regions.size() == 0) {
+			if(regions.isEmpty()) {
 				plugin.message(player, "cmd-noRegionsFound");
 				return;
 			}
@@ -72,10 +72,10 @@ public class GroupaddCommand extends CommandAreaShop {
 					namesFailed.add(region.getName());
 				}
 			}
-			if(namesSuccess.size() != 0) {
+			if(!namesSuccess.isEmpty()) {
 				plugin.message(player, "groupadd-weSuccess", group.getName(), Utils.createCommaSeparatedList(namesSuccess));
 			}
-			if(namesFailed.size() != 0) {
+			if(!namesFailed.isEmpty()) {
 				plugin.message(player, "groupadd-weFailed", group.getName(), Utils.createCommaSeparatedList(namesFailed));
 			}
 			// Update all regions, this does it in a task, updating them without lag

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/GroupdelCommand.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/GroupdelCommand.java
@@ -57,7 +57,7 @@ public class GroupdelCommand extends CommandAreaShop {
 				return;
 			}
 			List<GeneralRegion> regions = Utils.getASRegionsInSelection(selection);
-			if(regions.size() == 0) {
+			if(regions.isEmpty()) {
 				plugin.message(player, "cmd-noRegionsFound");
 				return;
 			}
@@ -72,10 +72,10 @@ public class GroupdelCommand extends CommandAreaShop {
 					namesFailed.add(region.getName());
 				}
 			}
-			if(namesSuccess.size() != 0) {
+			if(!namesSuccess.isEmpty()) {
 				plugin.message(player, "groupdel-weSuccess", group.getName(), Utils.createCommaSeparatedList(namesSuccess));
 			}
-			if(namesFailed.size() != 0) {
+			if(!namesFailed.isEmpty()) {
 				plugin.message(player, "groupdel-weFailed", group.getName(), Utils.createCommaSeparatedList(namesFailed));
 			}
 			// Update all regions, this does it in a task, updating them without lag

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/GroupinfoCommand.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/GroupinfoCommand.java
@@ -44,7 +44,7 @@ public class GroupinfoCommand extends CommandAreaShop {
 			return;
 		}
 		List<String> members = group.getMembers();
-		if(members.size() == 0) {
+		if(members.isEmpty()) {
 			plugin.message(sender, "groupinfo-noMembers", group.getName());
 		} else {
 			plugin.message(sender, "groupinfo-members", group.getName(), Utils.createCommaSeparatedList(members));

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/GrouplistCommand.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/commands/GrouplistCommand.java
@@ -33,7 +33,7 @@ public class GrouplistCommand extends CommandAreaShop {
 			return;
 		}
 		List<String> groups = plugin.getFileManager().getGroupNames();
-		if(groups.size() == 0) {
+		if(groups.isEmpty()) {
 			plugin.message(sender, "grouplist-noGroups");
 		} else {
 			plugin.message(sender, "grouplist-success", Utils.createCommaSeparatedList(groups));

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/managers/CommandManager.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/managers/CommandManager.java
@@ -150,7 +150,7 @@ public class CommandManager implements CommandExecutor, TabCompleter {
 			}
 		}
 		// Filter and sort the results
-		if(result.size() > 0) {
+		if(!result.isEmpty()) {
 			SortedSet<String> set = new TreeSet<>();
 			for(String suggestion : result) {
 				if(suggestion.toLowerCase().startsWith(toCompletePrefix)) {

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/managers/FileManager.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/managers/FileManager.java
@@ -771,7 +771,7 @@ public class FileManager {
 				InputStreamReader normal = new InputStreamReader(plugin.getResource(AreaShop.defaultFile), Charsets.UTF_8)
 		) {
 			defaultConfig = YamlConfiguration.loadConfiguration(custom);
-			if(defaultConfig.getKeys(false).size() == 0) {
+			if(defaultConfig.getKeys(false).isEmpty()) {
 				plugin.getLogger().warning("File 'default.yml' is empty, check for errors in the log.");
 				result = false;
 			} else {
@@ -812,7 +812,7 @@ public class FileManager {
 				InputStreamReader normal = new InputStreamReader(plugin.getResource(AreaShop.configFile), Charsets.UTF_8)
 		) {
 			config = YamlConfiguration.loadConfiguration(custom);
-			if(config.getKeys(false).size() == 0) {
+			if(config.getKeys(false).isEmpty()) {
 				plugin.getLogger().warning("File 'config.yml' is empty, check for errors in the log.");
 				result = false;
 			} else {
@@ -840,7 +840,7 @@ public class FileManager {
 					InputStreamReader reader = new InputStreamReader(new FileInputStream(groupFile), Charsets.UTF_8)
 			) {
 				groupsConfig = YamlConfiguration.loadConfiguration(reader);
-				if(config.getKeys(false).size() == 0) {
+				if(config.getKeys(false).isEmpty()) {
 					plugin.getLogger().warning("File 'groups.yml' is empty, check for errors in the log.");
 					result = false;
 				}
@@ -883,7 +883,7 @@ public class FileManager {
 							InputStreamReader reader = new InputStreamReader(new FileInputStream(regionFile), Charsets.UTF_8)
 					) {
 						config = YamlConfiguration.loadConfiguration(reader);
-						if(config.getKeys(false).size() == 0) {
+						if(config.getKeys(false).isEmpty()) {
 							plugin.getLogger().warning("Region file '"+regionFile.getName()+"' is empty, check for errors in the log.");
 						}
 					} catch(IOException e) {

--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/RegionGroup.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/regions/RegionGroup.java
@@ -41,7 +41,7 @@ public class RegionGroup {
 			AreaShop.debug("group save required because of changed member size");
 			saveRequired();
 		}
-		if(getMembers().size() == 0) {
+		if(getMembers().isEmpty()) {
 			plugin.getFileManager().removeGroup(this);
 		}
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1155  Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Zeeshan Asghar