### PR TITLE
The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/AreaShop/src/main/java/nl/evolutioncoding/areashop/Utils.java
+++ b/AreaShop/src/main/java/nl/evolutioncoding/areashop/Utils.java
@@ -22,10 +22,7 @@ import java.util.*;
 
 public class Utils {
 
-	// Not used
-	private Utils() {}
-
-	private static YamlConfiguration config;
+    private static YamlConfiguration config;
 	private static ArrayList<String> identifiers;
 	private static ArrayList<String> seconds;
 	private static ArrayList<String> minutes;
@@ -35,6 +32,9 @@ public class Utils {
 	private static ArrayList<String> months;
 	private static ArrayList<String> years;
 
+	// Not used
+    private Utils() {}
+    
 	public static void initialize(YamlConfiguration pluginConfig) {
 		config = pluginConfig;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1213 The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213 

Please let me know if you have any questions.

Zeeshan Asghar